### PR TITLE
Write interactions to s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ Use the -s command line option to "scrub" personal data from the file for test p
 ```$bash
  sbt "application/run -s -u <<desk.com username>> -p <<desk.com password>>" -o <<aws profile>> s3://<<s3 bucket>>/<<s3 path>>"
 ```
+
+For all command line options run the following:
+
+```$bash
+ sbt "application/run -h"
+```

--- a/README.md
+++ b/README.md
@@ -4,8 +4,14 @@ Command line tool supporting migration from desk.com to Sales Force Service Clou
 Usage
 =====
 
-To run the export use the following command
+To run the export use the following command:
 
 ```$bash
- sbt "application/run -u <<desk.com username>> -p <<desk.com password>>"
+ sbt "application/run -u <<desk.com username>> -p <<desk.com password>>" -o <<aws profile>> s3://<<s3 bucket>>/<<s3 path>>"
+```
+
+Use the -s command line option to "scrub" personal data from the file for test purposes:
+
+```$bash
+ sbt "application/run -s -u <<desk.com username>> -p <<desk.com password>>" -o <<aws profile>> s3://<<s3 bucket>>/<<s3 path>>"
 ```

--- a/application/src/main/scala/com/gu/deskcomexporttool/CommandLineRunner.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/CommandLineRunner.scala
@@ -12,7 +12,7 @@ trait CommandLineRunner {
 case class ExportConfig(fetchSize: Int = 100,
                         deskComApiConfig: DeskComApiConfig = DeskComApiConfig(baseUrl = "https://guardianuserhelp.desk.com",
                           username = "", password = ""),
-                        s3Config: S3Config = S3Config("s3://ophan-raw-deskdotcom-cases/interactions.csv", "ophan"))
+                        s3Config: S3Config = S3Config("s3://ophan-raw-deskdotcom-cases/interactions.csv", "ophan", false))
 
 object CommandLineRunner {
   private val log = LoggerFactory.getLogger(classOf[CommandLineRunner])
@@ -54,6 +54,9 @@ object CommandLineRunner {
           .text("desk.com password")
         opt[String]('o', "profile")
           .action((x, c) => c.copy(s3Config = c.s3Config.copy(awsProfile = x)))
+          .text("s3 export location s3://<<bucket>/<<path>>")
+        opt[Unit]('s', "scrub")
+          .action((_, c) => c.copy(s3Config = c.s3Config.copy(scrub = true)))
           .text("s3 export location s3://<<bucket>/<<path>>")
         arg[String]("<s3 export location>...")
           .unbounded()

--- a/application/src/main/scala/com/gu/deskcomexporttool/CommandLineRunner.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/CommandLineRunner.scala
@@ -11,7 +11,8 @@ trait CommandLineRunner {
 
 case class ExportConfig(fetchSize: Int = 100,
                         deskComApiConfig: DeskComApiConfig = DeskComApiConfig(baseUrl = "https://guardianuserhelp.desk.com",
-                          username = "", password = ""))
+                          username = "", password = ""),
+                        s3Config: S3Config = S3Config("s3://ophan-raw-deskdotcom-cases/interactions.csv", "ophan"))
 
 object CommandLineRunner {
   private val log = LoggerFactory.getLogger(classOf[CommandLineRunner])
@@ -51,6 +52,14 @@ object CommandLineRunner {
         opt[String]('p', "password")
           .action((x, c) => c.copy(deskComApiConfig = c.deskComApiConfig.copy(password = x)))
           .text("desk.com password")
+        opt[String]('o', "profile")
+          .action((x, c) => c.copy(s3Config = c.s3Config.copy(awsProfile = x)))
+          .text("s3 export location s3://<<bucket>/<<path>>")
+        arg[String]("<s3 export location>...")
+          .unbounded()
+          .optional()
+          .action((x, c) => c.copy(s3Config = c.s3Config.copy(location = x)))
+          .text("s3 export location")
       }
 
       private def returnFailure = Future.successful(FAILURE_CODE)

--- a/application/src/main/scala/com/gu/deskcomexporttool/CommandLineRunner.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/CommandLineRunner.scala
@@ -12,7 +12,7 @@ trait CommandLineRunner {
 case class ExportConfig(fetchSize: Int = 100,
                         deskComApiConfig: DeskComApiConfig = DeskComApiConfig(baseUrl = "https://guardianuserhelp.desk.com",
                           username = "", password = ""),
-                        s3Config: S3Config = S3Config("s3://ophan-raw-deskdotcom-cases/interactions.csv", "ophan", false))
+                        s3Config: S3Config = S3Config("s3://ophan-raw-deskdotcom-cases/interactions.csv", "ophan", scrub = false))
 
 object CommandLineRunner {
   private val log = LoggerFactory.getLogger(classOf[CommandLineRunner])

--- a/application/src/main/scala/com/gu/deskcomexporttool/DeskComClient.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/DeskComClient.scala
@@ -66,7 +66,7 @@ object DeskComClient {
   }
 }
 
-case class Interaction(id: Int, createdAt: String, updatedAt: String, body: String, from: String, to: String,
+case class Interaction(id: Int, createdAt: String, updatedAt: String, body: String, from: String, to: Option[String],
                        cc: Option[String], bcc: Option[String], direction: String, status: String, subject: String,
                        _links: InteractionLinks)
 

--- a/application/src/main/scala/com/gu/deskcomexporttool/DeskComClient.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/DeskComClient.scala
@@ -51,7 +51,7 @@ object DeskComClient {
       decode[GetInteractionsResponse](body)
         .leftMap { parsingFailure =>
           log.debug(s"Failed to parse response error:$parsingFailure response: $body")
-          DeskComApiError(s"Failed to parse interaction response: ${parsingFailure}")
+          DeskComApiError(s"Failed to parse interaction response: $parsingFailure")
         }
     }
 

--- a/application/src/main/scala/com/gu/deskcomexporttool/DeskComClient.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/DeskComClient.scala
@@ -26,6 +26,8 @@ object DeskComClient {
       s"Basic ${Base64.getEncoder.encodeToString(s"${config.username}:${config.password}".getBytes("UTF-8"))}"
     )
 
+    implicit val interactionLinkDecoder: Decoder[Link] = deriveDecoder(derivation.renaming.snakeCase)
+    implicit val interactionLinksDecoder: Decoder[InteractionLinks] = deriveDecoder(derivation.renaming.snakeCase)
     implicit val interactionDecoder: Decoder[Interaction] = deriveDecoder(derivation.renaming.snakeCase)
     implicit val interactionEmbeddedDecoder: Decoder[GetInteractionsEmbedded] = deriveDecoder(derivation.renaming.snakeCase)
     implicit val interactionResponseDecoder: Decoder[GetInteractionsResponse] = deriveDecoder(derivation.renaming.snakeCase)
@@ -65,7 +67,12 @@ object DeskComClient {
 }
 
 case class Interaction(id: Int, createdAt: String, updatedAt: String, body: String, from: String, to: String,
-                       cc: Option[String], bcc: Option[String], direction: String, status: String, subject: String)
+                       cc: Option[String], bcc: Option[String], direction: String, status: String, subject: String,
+                       _links: InteractionLinks)
+
+case class InteractionLinks(self: Link)
+
+case class Link(href: String)
 
 case class GetInteractionsEmbedded(entries: List[Interaction])
 

--- a/application/src/main/scala/com/gu/deskcomexporttool/DeskComClientFactory.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/DeskComClientFactory.scala
@@ -7,7 +7,5 @@ trait DeskComClientFactory {
 }
 
 object DeskComClientFactory {
-  def apply()(implicit ec: ExecutionContext): DeskComClientFactory = new DeskComClientFactory() {
-    override def createClient(config: DeskComApiConfig): DeskComClient = DeskComClient(config, HttpClient())
-  }
+  def apply()(implicit ec: ExecutionContext): DeskComClientFactory = (config: DeskComApiConfig) => DeskComClient(config, HttpClient())
 }

--- a/application/src/main/scala/com/gu/deskcomexporttool/Exporter.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/Exporter.scala
@@ -2,41 +2,59 @@ package com.gu.deskcomexporttool
 
 import cats.data.EitherT
 import cats.instances.future._
+import cats.instances.either._
+import cats.instances.list._
+import cats.syntax.either._
+import cats.syntax.traverse._
+import org.slf4j.LoggerFactory
 
 import scala.collection.immutable
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 
 trait Exporter {
   def export(config: ExportConfig): EitherT[Future, ExporterError, Unit]
 }
 
 object Exporter {
+  private val log = LoggerFactory.getLogger(this.getClass)
+
   def apply(s3Service: S3Service, deskComClientFactory: DeskComClientFactory)(implicit ec: ExecutionContext): Exporter = new Exporter() {
     override def export(config: ExportConfig): EitherT[Future, ExporterError, Unit] = {
       val deskComClient = deskComClientFactory.createClient(config.deskComApiConfig)
 
       for {
         s3Writer <- EitherT
-          .fromEither(s3Service.open(config.s3Config))
+          .fromEither[Future](s3Service.open(config.s3Config))
           .leftMap(error => ExporterError(s"Failed to create s3 writer: $error"))
-        res <- writeInteractions(deskComClient, s3Writer)
-      } yield res
+        _ <- writeInteractions(deskComClient, s3Writer)
+      } yield ()
     }
 
     private def writeInteractions(deskComClient: DeskComClient, s3Writer: S3InteractionsWriter) = {
-      val result = deskComClient
-        .getAllInteractions(1, 1)
-        .map { interactions: immutable.Seq[Interaction] =>
-          interactions.foreach(interaction => s3Writer.write(interaction))
+      val result =
+        for {
+          interactions <- deskComClient
+            .getAllInteractions(1, 1)
+            .leftMap(apiError => ExporterError(s"Export failed: $apiError"))
+          _ <- EitherT.fromEither[Future] {
+            interactions
+              .traverse[Either[S3Error, ?], Unit](interaction => s3Writer.write(interaction))
+              .leftMap(apiError => ExporterError(s"Export failed: $apiError"))
+          }
+        } yield ()
+
+      EitherT(
+        result.value.transform { result =>
+          Try {
+            s3Writer.close()
+            deskComClient.close()
+          }.recover {
+            case ex => log.error(s"Failed to shutdown gracefully: $ex")
+          }
+          result
         }
-        .leftMap(apiError => ExporterError(s"Export failed: $apiError"))
-
-      result.value.onComplete { _ =>
-        s3Writer.close()
-        deskComClient.close()
-      }
-
-      result
+      )
     }
   }
 }

--- a/application/src/main/scala/com/gu/deskcomexporttool/Exporter.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/Exporter.scala
@@ -17,7 +17,7 @@ object Exporter {
 
       for {
         s3Writer <- EitherT
-          .fromEither(s3Service.open(""))
+          .fromEither(s3Service.open(config.s3Config))
           .leftMap(error => ExporterError(s"Failed to create s3 writer: $error"))
         res <- writeInteractions(deskComClient, s3Writer)
       } yield res

--- a/application/src/main/scala/com/gu/deskcomexporttool/Exporter.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/Exporter.scala
@@ -26,15 +26,15 @@ object Exporter {
         s3Writer <- EitherT
           .fromEither[Future](s3Service.open(config.s3Config))
           .leftMap(error => ExporterError(s"Failed to create s3 writer: $error"))
-        _ <- writeInteractions(deskComClient, s3Writer)
+        _ <- writeInteractions(deskComClient, s3Writer, config.fetchSize)
       } yield ()
     }
 
-    private def writeInteractions(deskComClient: DeskComClient, s3Writer: S3InteractionsWriter) = {
+    private def writeInteractions(deskComClient: DeskComClient, s3Writer: S3InteractionsWriter, pageSize: Int) = {
       val result =
         for {
           interactions <- deskComClient
-            .getAllInteractions(1, 1)
+            .getAllInteractions(1, pageSize)
             .leftMap(apiError => ExporterError(s"Export failed: $apiError"))
           _ <- EitherT.fromEither[Future] {
             interactions

--- a/application/src/main/scala/com/gu/deskcomexporttool/Exporter.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/Exporter.scala
@@ -1,14 +1,13 @@
 package com.gu.deskcomexporttool
 
 import cats.data.EitherT
-import cats.instances.future._
 import cats.instances.either._
+import cats.instances.future._
 import cats.instances.list._
 import cats.syntax.either._
 import cats.syntax.traverse._
 import org.slf4j.LoggerFactory
 
-import scala.collection.immutable
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 

--- a/application/src/main/scala/com/gu/deskcomexporttool/HttpClient.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/HttpClient.scala
@@ -17,7 +17,7 @@ trait HttpClient {
 
 object HttpClient {
   def apply()(implicit ec: ExecutionContext): HttpClient = new HttpClient() {
-    private implicit val backend = AsyncHttpClientFutureBackend()
+    private implicit val backend: SttpBackend[Future, Nothing] = AsyncHttpClientFutureBackend()
 
     override def request(request: HttpRequest): EitherT[Future, HttpError, HttpResponse] = {
       println(request.url)
@@ -29,7 +29,7 @@ object HttpClient {
 
       for {
         sttpResponse <- EitherT.right(sttpRequest.send())
-        body <- EitherT.fromEither(sttpResponse.body).leftMap(HttpError(_))
+        body <- EitherT.fromEither(sttpResponse.body).leftMap(HttpError)
       } yield HttpResponse(sttpResponse.code, body)
     }
 

--- a/application/src/main/scala/com/gu/deskcomexporttool/HttpClient.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/HttpClient.scala
@@ -4,10 +4,10 @@ import java.net.URI
 
 import cats.data.EitherT
 import cats.instances.future._
-
-import scala.concurrent.{ExecutionContext, Future}
 import com.softwaremill.sttp._
 import com.softwaremill.sttp.asynchttpclient.future.AsyncHttpClientFutureBackend
+
+import scala.concurrent.{ExecutionContext, Future}
 
 trait HttpClient {
   def request(request: HttpRequest): EitherT[Future, HttpError, HttpResponse]

--- a/application/src/main/scala/com/gu/deskcomexporttool/S3BinaryWriter.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/S3BinaryWriter.scala
@@ -17,14 +17,8 @@ object S3BinaryWriter {
   def apply(location: String, profile: String): Either[S3Error, S3BinaryWriter] = {
     for {
       parsedLocation <- parseS3Location(location)
-      writer <- createWriter(parsedLocation, profile)
-    } yield writer
-  }
-
-  private def createWriter(s3Location: S3Location, profile: String) = {
-    for {
       awsClient <- createAwsClient(profile)
-      transferManager <- createTransferManager(s3Location, awsClient)
+      transferManager <- createTransferManager(parsedLocation, awsClient)
       stream <- openStream(transferManager, awsClient)
     } yield stream
   }

--- a/application/src/main/scala/com/gu/deskcomexporttool/S3BinaryWriter.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/S3BinaryWriter.scala
@@ -43,7 +43,7 @@ object S3BinaryWriter {
     }
   }
 
-  val S3LocationRegex = """s3:/(.*?)/(.*)""".r
+  val S3LocationRegex = """s3://(.*?)/(.*)""".r
   def parseS3Location(location: String) = location match {
     case S3LocationRegex(bucket, path) => Right(S3Location(bucket, path))
     case _ => Left(S3Error(s"Invalid s3 location: $location"))

--- a/application/src/main/scala/com/gu/deskcomexporttool/S3BinaryWriter.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/S3BinaryWriter.scala
@@ -21,7 +21,7 @@ object S3BinaryWriter {
     } yield writer
   }
 
-  def createWriter(s3Location: S3Location, profile: String) = {
+  private def createWriter(s3Location: S3Location, profile: String) = {
     Either.catchNonFatal {
       val awsClient = AmazonS3ClientBuilder.standard()
         .withCredentials(new ProfileCredentialsProvider(profile))
@@ -43,8 +43,9 @@ object S3BinaryWriter {
     }
   }
 
-  val S3LocationRegex = """s3://(.*?)/(.*)""".r
-  def parseS3Location(location: String) = location match {
+  private val S3LocationRegex = """s3://(.*?)/(.*)""".r
+
+  private def parseS3Location(location: String) = location match {
     case S3LocationRegex(bucket, path) => Right(S3Location(bucket, path))
     case _ => Left(S3Error(s"Invalid s3 location: $location"))
   }

--- a/application/src/main/scala/com/gu/deskcomexporttool/S3BinaryWriter.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/S3BinaryWriter.scala
@@ -5,7 +5,7 @@ import java.io.OutputStream
 import alex.mojaki.s3upload.StreamTransferManager
 import cats.syntax.either._
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 
 trait S3BinaryWriter {
   def outputStream(): OutputStream
@@ -22,25 +22,46 @@ object S3BinaryWriter {
   }
 
   private def createWriter(s3Location: S3Location, profile: String) = {
+    for {
+      awsClient <- createAwsClient(profile)
+      transferManager <- createTransferManager(s3Location, awsClient)
+      stream <- openStream(transferManager, awsClient)
+    } yield stream
+  }
+
+  private def createTransferManager(s3Location: S3Location, awsClient: AmazonS3) = {
     Either.catchNonFatal {
-      val awsClient = AmazonS3ClientBuilder.standard()
+      new StreamTransferManager(s3Location.bucket, s3Location.path, awsClient)
+    }.leftMap { ex =>
+      S3Error(s"Failed to create s3 transfer manager: $ex")
+    }
+  }
+
+  private def createAwsClient(profile: String) = {
+    Either.catchNonFatal {
+      AmazonS3ClientBuilder.standard()
         .withCredentials(new ProfileCredentialsProvider(profile))
         .build()
-
-      val streamTransferManager = new StreamTransferManager(s3Location.bucket, s3Location.path, awsClient)
-
-      val stream = streamTransferManager.getMultiPartOutputStreams.get(0)
-
-      new S3BinaryWriter() {
-        override def outputStream(): OutputStream = stream
-
-        override def close(): Unit = {
-          streamTransferManager.complete()
-        }
-      }
-    }.left.map { ex =>
-      S3Error(s"Failed to create connection to s3: $ex")
+    }.leftMap { ex =>
+      S3Error(s"Failed to create aws client: $ex")
     }
+  }
+
+  private def openStream(streamTransferManager: StreamTransferManager, awsClient: AmazonS3) = {
+      Either.catchNonFatal {
+        val stream = streamTransferManager.getMultiPartOutputStreams.get(0)
+
+        new S3BinaryWriter() {
+          override def outputStream(): OutputStream = stream
+
+          override def close(): Unit = {
+            streamTransferManager.complete()
+            awsClient.shutdown()
+          }
+        }
+      }.leftMap { ex =>
+        S3Error(s"Failed to open connection to s3: $ex")
+      }
   }
 
   private val S3LocationRegex = """s3://(.*?)/(.*)""".r

--- a/application/src/main/scala/com/gu/deskcomexporttool/S3BinaryWriter.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/S3BinaryWriter.scala
@@ -1,0 +1,38 @@
+package com.gu.deskcomexporttool
+
+import java.io.OutputStream
+
+import alex.mojaki.s3upload.StreamTransferManager
+import cats.syntax.either._
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+
+trait S3BinaryWriter {
+  def outputStream(): OutputStream
+
+  def close(): Unit
+}
+
+object S3BinaryWriter {
+  def apply(location: String): Either[S3Error, S3BinaryWriter] = {
+    Either.catchNonFatal {
+      val awsClient = AmazonS3ClientBuilder.standard()
+        .withCredentials(new ProfileCredentialsProvider("membership"))
+        .build()
+
+      val streamTransferManager = new StreamTransferManager("ophan-raw-deskdotcom-cases", "/test/interactions.csv", awsClient)
+
+      val stream = streamTransferManager.getMultiPartOutputStreams.get(0)
+
+      new S3BinaryWriter() {
+        override def outputStream(): OutputStream = stream
+
+        override def close(): Unit = {
+          streamTransferManager.complete()
+        }
+      }
+    }.left.map { ex =>
+      S3Error(s"Failed to create connection to s3: $ex")
+    }
+  }
+}

--- a/application/src/main/scala/com/gu/deskcomexporttool/S3BinaryWriter.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/S3BinaryWriter.scala
@@ -42,20 +42,20 @@ object S3BinaryWriter {
   }
 
   private def openStream(streamTransferManager: StreamTransferManager, awsClient: AmazonS3) = {
-      Either.catchNonFatal {
-        val stream = streamTransferManager.getMultiPartOutputStreams.get(0)
+    Either.catchNonFatal {
+      val stream = streamTransferManager.getMultiPartOutputStreams.get(0)
 
-        new S3BinaryWriter() {
-          override def outputStream(): OutputStream = stream
+      new S3BinaryWriter() {
+        override def outputStream(): OutputStream = stream
 
-          override def close(): Unit = {
-            streamTransferManager.complete()
-            awsClient.shutdown()
-          }
+        override def close(): Unit = {
+          streamTransferManager.complete()
+          awsClient.shutdown()
         }
-      }.leftMap { ex =>
-        S3Error(s"Failed to open connection to s3: $ex")
       }
+    }.leftMap { ex =>
+      S3Error(s"Failed to open connection to s3: $ex")
+    }
   }
 
   private val S3LocationRegex = """s3://(.*?)/(.*)""".r

--- a/application/src/main/scala/com/gu/deskcomexporttool/S3InteractionsWriter.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/S3InteractionsWriter.scala
@@ -62,7 +62,7 @@ object S3InteractionsWriter {
                 interaction.updatedAt,
                 scrubString(interaction.body, scrubSensitiveData),
                 scrubString(interaction.from, scrubSensitiveData),
-                scrubString(interaction.to, scrubSensitiveData),
+                scrubString(interaction.to.getOrElse(""), scrubSensitiveData),
                 scrubString(interaction.cc.getOrElse(""), scrubSensitiveData),
                 scrubString(interaction.bcc.getOrElse(""), scrubSensitiveData),
                 interaction.direction,

--- a/application/src/main/scala/com/gu/deskcomexporttool/S3InteractionsWriter.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/S3InteractionsWriter.scala
@@ -83,5 +83,4 @@ object S3InteractionsWriter {
       }
     )
   }
-
 }

--- a/application/src/main/scala/com/gu/deskcomexporttool/S3Service.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/S3Service.scala
@@ -9,7 +9,7 @@ trait S3Service {
 }
 
 object S3Service {
-  val log = LoggerFactory.getLogger(this.getClass)
+  private val log = LoggerFactory.getLogger(this.getClass)
 
   def apply()(implicit ec: ExecutionContext): S3Service = new S3Service() {
     def open(config: S3Config): Either[S3Error, S3InteractionsWriter] = {

--- a/application/src/main/scala/com/gu/deskcomexporttool/S3Service.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/S3Service.scala
@@ -1,7 +1,5 @@
 package com.gu.deskcomexporttool
 
-import org.slf4j.LoggerFactory
-
 import scala.concurrent.ExecutionContext
 
 trait S3Service {
@@ -9,15 +7,12 @@ trait S3Service {
 }
 
 object S3Service {
-  private val log = LoggerFactory.getLogger(this.getClass)
 
-  def apply()(implicit ec: ExecutionContext): S3Service = new S3Service() {
-    def open(config: S3Config): Either[S3Error, S3InteractionsWriter] = {
-      for {
-        binaryWriter <- S3BinaryWriter(config.location, config.awsProfile)
-        interactionsWriter <- S3InteractionsWriter(binaryWriter, config.scrub)
-      } yield interactionsWriter
-    }
+  def apply()(implicit ec: ExecutionContext): S3Service = (config: S3Config) => {
+    for {
+      binaryWriter <- S3BinaryWriter(config.location, config.awsProfile)
+      interactionsWriter <- S3InteractionsWriter(binaryWriter, config.scrub)
+    } yield interactionsWriter
   }
 }
 

--- a/application/src/main/scala/com/gu/deskcomexporttool/S3Service.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/S3Service.scala
@@ -5,16 +5,16 @@ import org.slf4j.LoggerFactory
 import scala.concurrent.ExecutionContext
 
 trait S3Service {
-  def open(location: String): Either[S3Error, S3InteractionsWriter]
+  def open(config: S3Config): Either[S3Error, S3InteractionsWriter]
 }
 
 object S3Service {
   val log = LoggerFactory.getLogger(this.getClass)
 
   def apply()(implicit ec: ExecutionContext): S3Service = new S3Service() {
-    def open(location: String): Either[S3Error, S3InteractionsWriter] = {
+    def open(config: S3Config): Either[S3Error, S3InteractionsWriter] = {
       for {
-        binaryWriter <- S3BinaryWriter("")
+        binaryWriter <- S3BinaryWriter(config.location, config.awsProfile)
         interactionsWriter <- S3InteractionsWriter(binaryWriter)
       } yield interactionsWriter
     }
@@ -22,3 +22,5 @@ object S3Service {
 }
 
 case class S3Error(message: String)
+
+case class S3Config(location: String, awsProfile: String)

--- a/application/src/main/scala/com/gu/deskcomexporttool/S3Service.scala
+++ b/application/src/main/scala/com/gu/deskcomexporttool/S3Service.scala
@@ -15,7 +15,7 @@ object S3Service {
     def open(config: S3Config): Either[S3Error, S3InteractionsWriter] = {
       for {
         binaryWriter <- S3BinaryWriter(config.location, config.awsProfile)
-        interactionsWriter <- S3InteractionsWriter(binaryWriter)
+        interactionsWriter <- S3InteractionsWriter(binaryWriter, config.scrub)
       } yield interactionsWriter
     }
   }
@@ -23,4 +23,4 @@ object S3Service {
 
 case class S3Error(message: String)
 
-case class S3Config(location: String, awsProfile: String)
+case class S3Config(location: String, awsProfile: String, scrub: Boolean)

--- a/application/src/test/scala/com/gu/deskcomexporttool/CommandLineRunnerSpec.scala
+++ b/application/src/test/scala/com/gu/deskcomexporttool/CommandLineRunnerSpec.scala
@@ -19,14 +19,14 @@ class CommandLineRunnerSpec extends FlatSpec with ScalaFutures with MustMatchers
     }
 
     CommandLineRunner(mockExporter).run(Array(
-      "-f", "50", "-u", "aUsername", "-p", "aPassword", "-o", "aprofile", "s3://bucket/path"
+      "-f", "50", "-u", "aUsername", "-p", "aPassword", "-o", "aprofile", "-s", "s3://bucket/path"
     )).futureValue mustBe 0
 
     config must equal(Some(
       ExportConfig(
         fetchSize = 50,
         DeskComApiConfig("https://guardianuserhelp.desk.com", "aUsername", "aPassword"),
-        S3Config("s3://bucket/path", "aprofile")
+        S3Config("s3://bucket/path", "aprofile", true)
       )
     ))
   }

--- a/application/src/test/scala/com/gu/deskcomexporttool/CommandLineRunnerSpec.scala
+++ b/application/src/test/scala/com/gu/deskcomexporttool/CommandLineRunnerSpec.scala
@@ -18,11 +18,17 @@ class CommandLineRunnerSpec extends FlatSpec with ScalaFutures with MustMatchers
       }
     }
 
-    CommandLineRunner(mockExporter).run(Array("-f", "50", "-u", "aUsername", "-p", "aPassword")).futureValue mustBe 0
+    CommandLineRunner(mockExporter).run(Array(
+      "-f", "50", "-u", "aUsername", "-p", "aPassword", "-o", "aprofile", "s3://bucket/path"
+    )).futureValue mustBe 0
 
     config must equal(Some(
-      ExportConfig(fetchSize = 50, DeskComApiConfig("https://guardianuserhelp.desk.com", "aUsername", "aPassword")))
-    )
+      ExportConfig(
+        fetchSize = 50,
+        DeskComApiConfig("https://guardianuserhelp.desk.com", "aUsername", "aPassword"),
+        S3Config("s3://bucket/path", "aprofile")
+      )
+    ))
   }
   it must "return error code if error is returned" in {
     val mockExporter = new Exporter {

--- a/application/src/test/scala/com/gu/deskcomexporttool/CommandLineRunnerSpec.scala
+++ b/application/src/test/scala/com/gu/deskcomexporttool/CommandLineRunnerSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest.{FlatSpec, MustMatchers}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class CommandLineRunnerSpec extends FlatSpec with ScalaFutures with MustMatchers with IntegrationPatience  {
+class CommandLineRunnerSpec extends FlatSpec with ScalaFutures with MustMatchers with IntegrationPatience {
   "CommandLineRunnerSpec" must "parse command line and run feed" in {
     var config: Option[ExportConfig] = None
     val mockExporter = new Exporter {
@@ -26,7 +26,7 @@ class CommandLineRunnerSpec extends FlatSpec with ScalaFutures with MustMatchers
       ExportConfig(
         fetchSize = 50,
         DeskComApiConfig("https://guardianuserhelp.desk.com", "aUsername", "aPassword"),
-        S3Config("s3://bucket/path", "aprofile", true)
+        S3Config("s3://bucket/path", "aprofile", scrub = true)
       )
     ))
   }

--- a/application/src/test/scala/com/gu/deskcomexporttool/CommandLineRunnerSpec.scala
+++ b/application/src/test/scala/com/gu/deskcomexporttool/CommandLineRunnerSpec.scala
@@ -2,13 +2,13 @@ package com.gu.deskcomexporttool
 
 import cats.data.EitherT
 import cats.instances.future._
-import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FlatSpec, MustMatchers}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class CommandLineRunnerSpec extends FlatSpec with ScalaFutures with MustMatchers {
+class CommandLineRunnerSpec extends FlatSpec with ScalaFutures with MustMatchers with IntegrationPatience  {
   "CommandLineRunnerSpec" must "parse command line and run feed" in {
     var config: Option[ExportConfig] = None
     val mockExporter = new Exporter {

--- a/application/src/test/scala/com/gu/deskcomexporttool/DeskComClientSpec.scala
+++ b/application/src/test/scala/com/gu/deskcomexporttool/DeskComClientSpec.scala
@@ -66,7 +66,7 @@ class DeskComClientSpec extends FlatSpec with ScalaFutures with MustMatchers wit
 }
 
 object DeskComClientSpec {
-  lazy val getAllInteractionsResponseBody = Source.fromResource("getAllInteractionsResponseBody.json").mkString
+  lazy val getAllInteractionsResponseBody: String = Source.fromResource("getAllInteractionsResponseBody.json").mkString
 
 }
 

--- a/application/src/test/scala/com/gu/deskcomexporttool/DeskComClientSpec.scala
+++ b/application/src/test/scala/com/gu/deskcomexporttool/DeskComClientSpec.scala
@@ -29,12 +29,7 @@ class DeskComClientSpec extends FlatSpec with ScalaFutures with MustMatchers wit
 
     Inside.inside(client.getAllInteractions(page, pageSize).value.futureValue) {
       case Right(interactions) =>
-        interactions must contain only
-          Interaction(1111, "2018-01-01T01:01:01Z", "2019-01-01T01:01:01Z", "test body 1111",
-            "Test User 1111 <testuser1111@test.com>", "<toaddress1111@test.com>", Some("<ccaddress1111@test.com>"),
-            Some("<bccaddress1111@test.com>"), "in", "received", "Test Subject 1111"
-          )
-
+        interactions must contain only InteractionFixture.interaction
     }
   }
   it must "return error if status is invalid" in {

--- a/application/src/test/scala/com/gu/deskcomexporttool/InteractionFixture.scala
+++ b/application/src/test/scala/com/gu/deskcomexporttool/InteractionFixture.scala
@@ -2,7 +2,7 @@ package com.gu.deskcomexporttool
 
 object InteractionFixture {
   val interaction = Interaction(1111, "2018-01-01T01:01:01Z", "2019-01-01T01:01:01Z", "test body 1111",
-    "Test User 1111 <testuser1111@test.com>", "<toaddress1111@test.com>", Some("<ccaddress1111@test.com>"),
+    "Test User 1111 <testuser1111@test.com>", Some("<toaddress1111@test.com>"), Some("<ccaddress1111@test.com>"),
     Some("<bccaddress1111@test.com>"), "in", "received", "Test Subject 1111",
     InteractionLinks(Link("/api/v2/cases/c11111/message"))
   )

--- a/application/src/test/scala/com/gu/deskcomexporttool/InteractionFixture.scala
+++ b/application/src/test/scala/com/gu/deskcomexporttool/InteractionFixture.scala
@@ -1,0 +1,9 @@
+package com.gu.deskcomexporttool
+
+object InteractionFixture {
+  val interaction = Interaction(1111, "2018-01-01T01:01:01Z", "2019-01-01T01:01:01Z", "test body 1111",
+    "Test User 1111 <testuser1111@test.com>", "<toaddress1111@test.com>", Some("<ccaddress1111@test.com>"),
+    Some("<bccaddress1111@test.com>"), "in", "received", "Test Subject 1111",
+    InteractionLinks(Link("/api/v2/cases/c11111/message"))
+  )
+}

--- a/application/src/test/scala/com/gu/deskcomexporttool/S3InteractionWriterSpec.scala
+++ b/application/src/test/scala/com/gu/deskcomexporttool/S3InteractionWriterSpec.scala
@@ -23,7 +23,7 @@ class S3InteractionWriterSpec extends FlatSpec with ScalaFutures with MustMatche
         new String(writtenData.toByteArray, "UTF-8") must equal(
           "\"case_id\",\"created_at\",\"updated_at\",\"body\",\"from\",\"to\",\"cc\",\"bcc\",\"direction\"," +
             "\"status\",\"subject\"\n" +
-            "\"todo\",\"2018-01-01T01:01:01Z\",\"2019-01-01T01:01:01Z\",\"test body 1111\"," +
+            "\"c11111\",\"2018-01-01T01:01:01Z\",\"2019-01-01T01:01:01Z\",\"test body 1111\"," +
             "\"Test User 1111 <testuser1111@test.com>\",\"<toaddress1111@test.com>\",\"<ccaddress1111@test.com>\"," +
             "\"<bccaddress1111@test.com>\",\"in\",\"received\",\"Test Subject 1111\"\n"
         )

--- a/application/src/test/scala/com/gu/deskcomexporttool/S3InteractionWriterSpec.scala
+++ b/application/src/test/scala/com/gu/deskcomexporttool/S3InteractionWriterSpec.scala
@@ -1,0 +1,32 @@
+package com.gu.deskcomexporttool
+
+import java.io.{ByteArrayOutputStream, OutputStream}
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FlatSpec, Inside, MustMatchers}
+
+class S3InteractionWriterSpec extends FlatSpec with ScalaFutures with MustMatchers {
+  "S3InteractionWriter" must "format interaction as csv" in {
+    val writtenData = new ByteArrayOutputStream()
+    val mockBinaryWriter = new S3BinaryWriter {
+      override def outputStream(): OutputStream = writtenData
+
+      override def close(): Unit = ()
+    }
+
+    Inside.inside(S3InteractionsWriter(mockBinaryWriter)) {
+      case Right(interactionWriter) =>
+        interactionWriter.write(InteractionFixture.interaction) must equal(Right(()))
+
+        interactionWriter.close()
+
+        new String(writtenData.toByteArray, "UTF-8") must equal(
+          "\"case_id\",\"created_at\",\"updated_at\",\"body\",\"from\",\"to\",\"cc\",\"bcc\",\"direction\"," +
+            "\"status\",\"subject\"\n" +
+            "\"todo\",\"2018-01-01T01:01:01Z\",\"2019-01-01T01:01:01Z\",\"test body 1111\"," +
+            "\"Test User 1111 <testuser1111@test.com>\",\"<toaddress1111@test.com>\",\"<ccaddress1111@test.com>\"," +
+            "\"<bccaddress1111@test.com>\",\"in\",\"received\",\"Test Subject 1111\"\n"
+        )
+    }
+  }
+}

--- a/application/src/test/scala/com/gu/deskcomexporttool/S3InteractionWriterSpec.scala
+++ b/application/src/test/scala/com/gu/deskcomexporttool/S3InteractionWriterSpec.scala
@@ -14,7 +14,7 @@ class S3InteractionWriterSpec extends FlatSpec with ScalaFutures with MustMatche
       override def close(): Unit = ()
     }
 
-    Inside.inside(S3InteractionsWriter(mockBinaryWriter, false)) {
+    Inside.inside(S3InteractionsWriter(mockBinaryWriter, scrubSensitiveData = false)) {
       case Right(interactionWriter) =>
         interactionWriter.write(InteractionFixture.interaction) must equal(Right(()))
 
@@ -37,7 +37,7 @@ class S3InteractionWriterSpec extends FlatSpec with ScalaFutures with MustMatche
       override def close(): Unit = ()
     }
 
-    Inside.inside(S3InteractionsWriter(mockBinaryWriter, true)) {
+    Inside.inside(S3InteractionsWriter(mockBinaryWriter, scrubSensitiveData = true)) {
       case Right(interactionWriter) =>
         interactionWriter.write(InteractionFixture.interaction) must equal(Right(()))
 

--- a/build.sbt
+++ b/build.sbt
@@ -23,4 +23,5 @@ lazy val application = (project in file("application"))
       "-feature",
       "-language:postfixOps"
     ),
+    addCompilerPlugin("org.typelevel" % "kind-projector" % "0.10.3" cross CrossVersion.binary),
   )

--- a/build.sbt
+++ b/build.sbt
@@ -6,11 +6,14 @@ lazy val application = (project in file("application"))
   .settings(
     libraryDependencies ++= Seq(
       "ch.qos.logback" % "logback-classic" % "1.2.3",
+      "com.amazonaws" % "aws-java-sdk-s3" % "1.11.613",
+      "com.github.alexmojaki" % "s3-stream-upload" % "2.0.0",
       "com.github.scopt" %% "scopt" % "3.7.1",
       "com.softwaremill.sttp" %% "async-http-client-backend-future" % "1.6.4",
       "com.softwaremill.sttp" %% "core" % "1.6.4",
       "io.circe" %% "circe-parser" % "0.11.1",
       "io.circe" %% "circe-derivation" % "0.11.0-M2",
+      "org.apache.commons" % "commons-csv" % "1.7",
       "org.typelevel" %% "cats-core" % "1.6.1",
     ),
     libraryDependencies ++= Seq(


### PR DESCRIPTION
This PR implements the writing of Interactions to s3 in the form of CSV.

This includes:
- Serialisation to CSV using circe
- 'scrub' option to anonymise interaction data
- Writing of data to s3 using aws java client and s3-stream-upload lib
- Additional wiring to improve error reporting and command line config